### PR TITLE
Inclusion of complete DEXSeq results in tabular output

### DIFF
--- a/scripts/de_analysis.R
+++ b/scripts/de_analysis.R
@@ -101,7 +101,7 @@ dxr.g<-data.frame(gene=names(qval), qval)
 dxr.g <- dxr.g[order(dxr.g$qval),]
 
 dxr_out <- as.data.frame(dxr[,c("featureID", "groupID", "pvalue")])
-dxr_out <- dxr[order(dxr$pvalue),]
+dxr_out <- dxr_out[order(dxr$pvalue),]
 
 write.table(dxr.g, file="de_analysis/results_dtu_gene.tsv", sep="\t")
 write.table(dxr_out, file="de_analysis/results_dtu_transcript.tsv", sep="\t")

--- a/scripts/de_analysis.R
+++ b/scripts/de_analysis.R
@@ -100,11 +100,19 @@ qval <- perGeneQValue(dxr)
 dxr.g<-data.frame(gene=names(qval), qval)
 dxr.g <- dxr.g[order(dxr.g$qval),]
 
-dxr <- as.data.frame(dxr[,c("featureID", "groupID", "pvalue")])
-dxr <- dxr[order(dxr$pvalue),]
+dxr_out <- as.data.frame(dxr[,c("featureID", "groupID", "pvalue")])
+dxr_out <- dxr[order(dxr$pvalue),]
 
 write.table(dxr.g, file="de_analysis/results_dtu_gene.tsv", sep="\t")
-write.table(dxr, file="de_analysis/results_dtu_transcript.tsv", sep="\t")
+write.table(dxr_out, file="de_analysis/results_dtu_transcript.tsv", sep="\t")
+
+# and writing out some of the DEXSeq metrics to accompany EPI2ME Labs tutorial
+colnames(dxr)[grep("log2fold", colnames(dxr))] <- "log2fold"
+MADTUdata <- data.frame(dxr)[order(dxr$padj),c("exonBaseMean", "log2fold", "pvalue", "padj")]
+MADTUdata$exonBaseMean <- log2(MADTUdata$exonBaseMean)
+colnames(MADTUdata)[which(colnames(MADTUdata)=="exonBaseMean")] <- "Log2MeanExon"
+colnames(MADTUdata)[which(colnames(MADTUdata)=="log2fold")] <- "Log2FC"
+write.table(MADTUdata, file="de_analysis/results_dexseq.tsv", sep="\t")
 
 # stageR analysis of DEXSeq results:
 cat("stageR analysis\n")


### PR DESCRIPTION
Hei Botond - simple PR here - for the EPI2ME Labs DGE tutorial we would like to render the results from DEXSeq as an MA plot. The standard DEXSeq results are reduced in the standard output; I am adding a new file with the complete DEXSeq output for additional parsing - this does not change any of the standard output; just adds a new file with rich numeric content.
Thanks for the consideration - Stephen