### PR TITLE
directional fix to the R code; env.yml and config with minor updates

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,7 +16,7 @@ repo: "https://github.com/nanoporetech/pipeline-transcriptome-de"
 transcriptome: "Homo_sapiens.GRCh38.cdna.all.fa"
 
 # Annotation GFF/GTF
-annotation: "Homo_sapiens.GRCh38.93.gtf"
+annotation: "Homo_sapiens.GRCh38.102.gtf"
 
 # Control samples
 control_samples:

--- a/env.yml
+++ b/env.yml
@@ -11,6 +11,7 @@ dependencies:
     - minimap2
     - samtools
     - r-dplyr
+    - r-tidyr
     - pysam
     - pandas
     - salmon

--- a/scripts/de_analysis.R
+++ b/scripts/de_analysis.R
@@ -7,9 +7,9 @@ cat("Loading counts, conditions and parameters.\n")
 cts <- as.matrix(read.csv("merged/all_counts.tsv", sep="\t", row.names="Reference", stringsAsFactors=FALSE))
 
 # Set up sample data frame:
-coldata <- read.csv("de_analysis/coldata.tsv", row.names="sample", sep="\t")
+coldata <- read.csv("de_analysis/coldata.tsv", row.names="sample", sep="\t", stringsAsFactors=TRUE)
 coldata$sample_id <- rownames(coldata)
-coldata$condition <- factor(coldata$condition, levels=rev(unique(coldata$condition)))
+coldata$condition <- factor(coldata$condition, levels=rev(levels(coldata$condition)))
 
 de_params <- read.csv("de_analysis/de_params.tsv", sep="\t", stringsAsFactors=FALSE)
 


### PR DESCRIPTION
Hei Botond - as discussed in December, here is our agreed fix for the directional flip in the de_analysis.R script - the default behaviour of stringsAsFactors in read_csv has changed; the solution is an explicit stringsAsFactors=TRUE in the import and a reversion to your reversed levels code ... I have touched a version number in the config.yaml (of no consequence but more contemporary pointer to the EMBL dataset) and I have added r-tidyr as a dependency in env.yml that appears to have crept in ...

tested and validated - appears robust