### PR TITLE
convert workflow.included to list of strings

### DIFF
--- a/snakelib/utils.snake
+++ b/snakelib/utils.snake
@@ -11,7 +11,7 @@ def generate_help(sfile):
 
 rule help: ## print list of all targets with help
     input:
-        workflow.included
+        [str(x) for x in workflow.included]
     run:
         print("--------------------------------------------")
         [generate_help(sfile) for sfile in input]


### PR DESCRIPTION
This is a simple fix of #33 to convert the workflow.included object into a list of strings. 